### PR TITLE
Add default values to the SelectionState interface

### DIFF
--- a/library/src/main/java/io/github/boguszpawlowski/composecalendar/selection/SelectionState.kt
+++ b/library/src/main/java/io/github/boguszpawlowski/composecalendar/selection/SelectionState.kt
@@ -11,8 +11,8 @@ import java.time.LocalDate
 
 @Stable
 public interface SelectionState {
-  public fun isDateSelected(date: LocalDate): Boolean
-  public fun onDateSelected(date: LocalDate)
+  public fun isDateSelected(date: LocalDate): Boolean = false
+  public fun onDateSelected(date: LocalDate) { }
 }
 
 /**

--- a/library/src/test/java/io/github/boguszpawlowski/composecalendar/selection/SelectionStateTest.kt
+++ b/library/src/test/java/io/github/boguszpawlowski/composecalendar/selection/SelectionStateTest.kt
@@ -2,6 +2,7 @@
 
 package io.github.boguszpawlowski.composecalendar.selection
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
@@ -133,6 +134,20 @@ internal class SelectionStateTest : ShouldSpec({
 
       state.selection.first() shouldBe yesterday
       state.selection.endOrNull() shouldBe null
+    }
+  }
+
+  context("Selection State interface default values") {
+    val myInterfaceWithNoMethods = object : SelectionState {}
+
+    should("Default isDateSelected to false") {
+      myInterfaceWithNoMethods.isDateSelected(today) shouldBe false
+    }
+
+    should("Have a default implementation that doesn't throw an exception for onDateSelected") {
+      shouldNotThrowAny {
+        myInterfaceWithNoMethods.onDateSelected(today)
+      }
     }
   }
 })


### PR DESCRIPTION
This commit adds default values to the SelectionState interface.

This is useful to avoid unnecessary empty default implementations, while still allowing the method to be overriden.

The tests added can infer correctly that the date selected is false, but this author couldn't think of a better test to "thid method shouldn't do anything", so I've added a check to ensure no exceptions are thrown.

Closes #58